### PR TITLE
Feature enquiryPeriod endDate set and validation

### DIFF
--- a/docs/source/locale/uk/LC_MESSAGES/overview.po
+++ b/docs/source/locale/uk/LC_MESSAGES/overview.po
@@ -116,6 +116,12 @@ msgstr "`tenderPeriod` має складати щонайменше 7 кален
 msgid "Organizer can edit procedure only during *enquiryPeriod*. "
 msgstr "Організатор може редагувати аукціон тільки впродовж *enquiryPeriod*. "
 
+msgid "Optionally Organizer can set *enquiryPeriod.endDate*."
+msgstr "Також додатково Організатор має можливість встановити *enquiryPeriod.endDate*."
+
+msgid "If *enquiryPeriod.endDate* is not provided it will be calculated automatically."
+msgstr "Якщо *enquiryPeriod.endDate* не передано, ця дата встановлюється автоматично."
+
 msgid "Procedure can be switched from *draft* status to *active.tendering*."
 msgstr "Процедура переходить зі статусу *draft* до *active.tendering*."
 
@@ -167,10 +173,9 @@ msgstr ""
 "*Auction.value*."
 
 msgid ""
-"The only date Organizer has to provide is *Tender.auctionPeriod.startDate*, "
-"the rest will be calculated automatically."
+"The only date Organizer has to provide is *Tender.auctionPeriod.startDate*, the rest will be calculated automatically."
 msgstr ""
-"Єдина дата, яку потрібно надати, це дата початку аукціону "
+"Організатор може передати тільки дату початку аукціону "
 "*Tender.auctionPeriod.startDate*. Всі решта дати будуть обраховані на її "
 "основі."
 

--- a/docs/source/locale/uk/LC_MESSAGES/tutorial.po
+++ b/docs/source/locale/uk/LC_MESSAGES/tutorial.po
@@ -101,6 +101,17 @@ msgstr "Організатор може редагувати аукціон ті
 msgid "When this period ends 403 error will be returned on editing attempt:"
 msgstr "Після закінчення цього періоду на спробу редагування буде повернуто помилку 403: "
 
+msgid "Organizer can set *enquiryPeriod.endDate*. The difference between the given date and *tenderPeriod.endDate* should not be less than 5 working days."
+msgstr "Організатор має можливість встановити *enquiryPeriod.endDate*. Ця дата повинна бути не пізніша, ніж за 5 днів до *tenderPeriod.endDate*."
+
+msgid "If the duration between *enquiryPeriod.endDate* provided by Organizer and *tenderPeriod.endDate* is less than 5 days `422 Unprocessable Entity` response will be returned with the error message '*enquiryPeriod.endDate* should come at least 5 working days earlier than tenderPeriod.endDate.'"
+msgstr "Якщо *enquiryPeriod.endDate*, яку передав Організатор, буде ближчою, ніж 5 днів до *tenderPeriod.endDate*, "
+"згенерується помилка `422 Unprocessable Entity` та у JSON відповіді буде передано повідомлення "
+"'*enquiryPeriod.endDate* should come at least 5 working days earlier than tenderPeriod.endDate.'"
+
+msgid "If Organizer does not set *enquiryPeriod.endDate* it will be calculated automatically as *tenderPeriod.endDate* minus 5 working days."
+msgstr "Якщо *enquiryPeriod.endDate* не передано Організатором, кінцева дата періоду встановлюється автоматично на дату за 5 робочих днів до *tenderPeriod.endDate*."
+
 msgid "Uploading documentation"
 msgstr "Завантаження документації"
 

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -13,12 +13,13 @@ There are two procedures:
 Features
 --------
 
-* No need to specify enquiries period (there is no *active.enquiries* status), since it overlaps with *active.tendering* period.
+* The only date Organizer has to provide is *Tender.auctionPeriod.startDate*, the rest will be calculated automatically.
+* Optionally Organizer can set *enquiryPeriod.endDate*.
+* If *enquiryPeriod.endDate* is not provided it will be calculated automatically.
 * `tenderPeriod` must be at least 7 calendar days.
 * Organizer can edit procedure only during *enquiryPeriod*.
 * Procedure can be switched from *draft* status to *active.tendering*.
 * During *active.tendering* period participants can ask questions, submit proposals, and upload documents.
-* The only date Organizer has to provide is *Tender.auctionPeriod.startDate*, the rest will be calculated automatically.
 * Organizer can't edit procedure's significant properties (*Auction.value*, etc.).
 * There is obligatory participant qualification (*Bid.selfQualified*) via guarantee payment.
 * The only currency (*Value.currency*) for this procedure is hryvnia (UAH).

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -58,6 +58,12 @@ will be returned:
 .. include:: tutorial/tenderperiod-validation-error.http
    :code:
 
+Organizer can set *enquiryPeriod.endDate*. The difference between the given date and *tenderPeriod.endDate* should not be less than 5 working days.
+
+If the duration between *enquiryPeriod.endDate* provided by Organizer and *tenderPeriod.endDate* is less than 5 days `422 Unprocessable Entity` response will be returned with the error message '*enquiryPeriod.endDate* should come at least 5 working days earlier than tenderPeriod.endDate.'
+
+If Organizer does not set *enquiryPeriod.endDate* it will be calculated automatically as *tenderPeriod.endDate* minus 5 working days.
+
 Let's access the URL of the created object (the `Location` header of the response):
 
 .. include:: tutorial/blank-auction-view.http

--- a/openprocurement/auctions/dgf/constants.py
+++ b/openprocurement/auctions/dgf/constants.py
@@ -5,3 +5,5 @@ from openprocurement.api.models import (TZ)
 
 MINIMAL_EXPOSITION_PERIOD = timedelta(days=7)
 MINIMAL_EXPOSITION_REQUIRED_FROM = datetime(2017, 11, 17, tzinfo=TZ)
+MINIMAL_PERIOD_FROM_ENQUIRY_END = timedelta(days=5)
+ENQUIRY_END_EDITING_AND_VALIDATION_REQUIRED_FROM = datetime(2017, 12, 29, tzinfo=TZ)

--- a/openprocurement/auctions/dgf/tests/base.py
+++ b/openprocurement/auctions/dgf/tests/base.py
@@ -233,7 +233,7 @@ class BaseAuctionWebTest(FlashBaseAuctionWebTest):
         self.set_status('active.tendering', {
             "enquiryPeriod": {
                 "startDate": (now - timedelta(days=14)).isoformat(),
-                "endDate": (now - (timedelta(minutes=1) if SANDBOX_MODE else timedelta(days=1))).isoformat()
+                "endDate": (now - (timedelta(minutes=6) if SANDBOX_MODE else timedelta(days=6))).isoformat()
             },
             "tenderPeriod": {
                 "startDate": (now - timedelta(days=14)).isoformat(),
@@ -250,7 +250,7 @@ class BaseAuctionWebTest(FlashBaseAuctionWebTest):
             data.update({
                 "enquiryPeriod": {
                     "startDate": (now).isoformat(),
-                    "endDate": (now + timedelta(days=7)).isoformat()
+                    "endDate": (now + timedelta(days=1)).isoformat()
                 },
                 "tenderPeriod": {
                     "startDate": (now).isoformat(),
@@ -261,7 +261,7 @@ class BaseAuctionWebTest(FlashBaseAuctionWebTest):
             data.update({
                 "enquiryPeriod": {
                     "startDate": (now - timedelta(days=7)).isoformat(),
-                    "endDate": (now).isoformat()
+                    "endDate": (now - timedelta(days=6)).isoformat()
                 },
                 "tenderPeriod": {
                     "startDate": (now - timedelta(days=7)).isoformat(),
@@ -286,7 +286,7 @@ class BaseAuctionWebTest(FlashBaseAuctionWebTest):
             data.update({
                 "enquiryPeriod": {
                     "startDate": (now - timedelta(days=8)).isoformat(),
-                    "endDate": (now - timedelta(days=1)).isoformat()
+                    "endDate": (now - timedelta(days=6)).isoformat()
                 },
                 "tenderPeriod": {
                     "startDate": (now - timedelta(days=8)).isoformat(),
@@ -316,7 +316,7 @@ class BaseAuctionWebTest(FlashBaseAuctionWebTest):
             data.update({
                 "enquiryPeriod": {
                     "startDate": (now - timedelta(days=8)).isoformat(),
-                    "endDate": (now - timedelta(days=1)).isoformat()
+                    "endDate": (now - timedelta(days=6)).isoformat()
                 },
                 "tenderPeriod": {
                     "startDate": (now - timedelta(days=8)).isoformat(),
@@ -347,7 +347,7 @@ class BaseAuctionWebTest(FlashBaseAuctionWebTest):
             data.update({
                 "enquiryPeriod": {
                     "startDate": (now - timedelta(days=18)).isoformat(),
-                    "endDate": (now - timedelta(days=11)).isoformat()
+                    "endDate": (now - timedelta(days=17)).isoformat()
                 },
                 "tenderPeriod": {
                     "startDate": (now - timedelta(days=18)).isoformat(),

--- a/openprocurement/auctions/dgf/tests/chronograph.py
+++ b/openprocurement/auctions/dgf/tests/chronograph.py
@@ -183,6 +183,8 @@ class AuctionAuctionPeriodResourceTest(BaseAuctionWebTest):
         self.assertGreater(auction['next_check'], response.json['data']['tenderPeriod']['endDate'])
         auction['tenderPeriod']['endDate'] = auction['tenderPeriod']['startDate']
         auction['tenderPeriod']['startDate'] = (datetime.strptime(auction['tenderPeriod']['endDate'][:19], "%Y-%m-%dT%H:%M:%S")  - timedelta(days=10)).isoformat()
+        auction['enquiryPeriod']['startDate'] = (datetime.strptime(auction['tenderPeriod']['endDate'][:19], "%Y-%m-%dT%H:%M:%S")  - timedelta(days=10)).isoformat()
+        auction['enquiryPeriod']['endDate'] = (datetime.strptime(auction['tenderPeriod']['endDate'][:19], "%Y-%m-%dT%H:%M:%S")  - timedelta(days=5)).isoformat()
         if self.initial_lots:
             auction['lots'][0]['auctionPeriod']['startDate'] = auction['tenderPeriod']['endDate']
         else:

--- a/openprocurement/auctions/dgf/utils.py
+++ b/openprocurement/auctions/dgf/utils.py
@@ -102,3 +102,8 @@ def check_status(request):
             if standStillEnd <= now:
                 check_auction_status(request)
                 return
+
+
+def get_auction_creation_date(data):
+    auction_creation_date = (data.get('revisions')[0].date if data.get('revisions') else get_now())
+    return auction_creation_date


### PR DESCRIPTION
Цей pull request додає можливість організатору встановити enquiryPeriod та вводить валідацію цих данних — між enquiryPeriod.endDate та tenderPeriod.endDate має бути не менш, ніж Х днів. Наразі Х = 5 днів.
