### PR TITLE
Feature set bids to invalid status when auction edited

### DIFF
--- a/docs/source/locale/uk/LC_MESSAGES/overview.po
+++ b/docs/source/locale/uk/LC_MESSAGES/overview.po
@@ -119,6 +119,9 @@ msgstr "Організатор може редагувати аукціон ті
 msgid "Optionally Organizer can set *enquiryPeriod.endDate*."
 msgstr "Також додатково Організатор має можливість встановити *enquiryPeriod.endDate*."
 
+msgid "As soon as the action is edited, the status of all of the submitted bids will be switched to `invalid`."
+msgstr "Кожного разу після редагування аукціону статус всіх ставок перемикається на `invalid`."
+
 msgid "If *enquiryPeriod.endDate* is not provided it will be calculated automatically."
 msgstr "Якщо *enquiryPeriod.endDate* не передано, ця дата встановлюється автоматично."
 

--- a/docs/source/locale/uk/LC_MESSAGES/tutorial.po
+++ b/docs/source/locale/uk/LC_MESSAGES/tutorial.po
@@ -92,6 +92,12 @@ msgstr ""
 "Додатково оновлена властивість `dateModified`, щоб відображати останню дату "
 "модифікації."
 
+msgid "Keep in mind, that every time Organizer edits the auction all bids will be switched to `invalid` status."
+msgstr "Пам'ятайте, що кожного разу, коли Організатор редагує аукціон, статус всіх ставок перемикається на `invalid`."
+
+msgid "Bidders can reactivate their bids."
+msgstr "Після цього учасники можуть наново активувати власні ставки."
+
 msgid "Checking the listing again reflects the new modification date:"
 msgstr "Ще одна перевірка списку відображає нову дату модифікації:"
 

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -18,6 +18,7 @@ Features
 * If *enquiryPeriod.endDate* is not provided it will be calculated automatically.
 * `tenderPeriod` must be at least 7 calendar days.
 * Organizer can edit procedure only during *enquiryPeriod*.
+* As soon as the action is edited, the status of all of the submitted bids will be switched to `invalid`.
 * Procedure can be switched from *draft* status to *active.tendering*.
 * During *active.tendering* period participants can ask questions, submit proposals, and upload documents.
 * Organizer can't edit procedure's significant properties (*Auction.value*, etc.).

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -111,6 +111,10 @@ Checking the listing again reflects the new modification date:
 .. include:: tutorial/auction-listing-after-patch.http
    :code:
 
+Keep in mind, that every time Organizer edits the auction all bids will be switched to `invalid` status.
+
+Bidders can reactivate their bids.
+
 Organizer can edit procedure only during *enquiryPeriod*.
 
 When this period ends 403 error will be returned on editing attempt:

--- a/openprocurement/auctions/dgf/utils.py
+++ b/openprocurement/auctions/dgf/utils.py
@@ -63,6 +63,7 @@ def check_status(request):
                     extra=context_unpack(request, {'MESSAGE_ID': 'switched_auction_active.auction'}))
         auction.status = 'active.auction'
         remove_draft_bids(request)
+        remove_invalid_bids(request)
         check_bids(request)
         return
     elif auction.lots and auction.status == 'active.tendering' and auction.tenderPeriod.endDate <= now:
@@ -70,6 +71,7 @@ def check_status(request):
                     extra=context_unpack(request, {'MESSAGE_ID': 'switched_auction_active.auction'}))
         auction.status = 'active.auction'
         remove_draft_bids(request)
+        remove_invalid_bids(request)
         check_bids(request)
         [setattr(i.auctionPeriod, 'startDate', None) for i in auction.lots if i.numberOfBids < 2 and i.auctionPeriod]
         return
@@ -107,3 +109,17 @@ def check_status(request):
 def get_auction_creation_date(data):
     auction_creation_date = (data.get('revisions')[0].date if data.get('revisions') else get_now())
     return auction_creation_date
+
+
+def remove_invalid_bids(request):
+    auction = request.validated['auction']
+    if [bid for bid in auction.bids if getattr(bid, "status", "active") == "invalid"]:
+        LOGGER.info('Remove invalid bids',
+                    extra=context_unpack(request, {'MESSAGE_ID': 'remove_invalid_bids'}))
+        auction.bids = [bid for bid in auction.bids if getattr(bid, "status", "active") != "invalid"]
+
+
+def invalidate_bids_data(request):
+    auction = request.validated['auction']
+    for bid in auction.bids:
+        setattr(bid, "status", "invalid")

--- a/openprocurement/auctions/dgf/views/other/tender.py
+++ b/openprocurement/auctions/dgf/views/other/tender.py
@@ -14,6 +14,7 @@ from openprocurement.auctions.core.validation import (
 )
 from openprocurement.auctions.dgf.utils import (
     check_status,
+    invalidate_bids_data
 )
 from openprocurement.auctions.dgf.validation import (
     validate_change_price_criteria_reduction,
@@ -190,7 +191,10 @@ class AuctionResource(APIResource):
             check_status(self.request)
             save_auction(self.request)
         else:
-            apply_patch(self.request, src=self.request.validated['auction_src'])
+            apply_patch(self.request, save=False, src=self.request.validated['auction_src'])
+            if auction.status == 'active.tendering':
+                invalidate_bids_data(self.request)
+            save_auction(self.request)
         self.LOGGER.info('Updated auction {}'.format(auction.id),
                     extra=context_unpack(self.request, {'MESSAGE_ID': 'auction_patch'}))
         return {'data': auction.serialize(auction.status)}


### PR DESCRIPTION
Цей pull request додає `bids` новий статус `invalid`, та вводить скидання всіх `bids` у цей статус після кожного редагування аукціону під час `enquiryPeriod`.
Після інвалідації `bids`, учасник має можливість оцінити нові умови аукціону та реактивувати свій `bid`.